### PR TITLE
Add a config option to disable all default keymaps

### DIFF
--- a/doc/litee.nvim
+++ b/doc/litee.nvim
@@ -237,6 +237,15 @@ a LITEE.nvim window.
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTSelectFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTDeSelectFiletree<CR>", opts)
 
+To disable the above default mappings, you can set config.disable_default_keymaps to true.
+
+To add your own keymaps, you can use the filetype "litee" to narrow the bindings to 
+be mapped solely on Litee side buffers:
+
+  vim.cmd(([[
+  autocmd Filetype calltree lua vim.api.nvim_set_keymap("n", "<Tab>", ":LTExpand<CR>", {})
+  autocmd Filetype calltree lua vim.api.nvim_set_keymap("n", ...)
+  ]]))
 
 ====================================================================================
 CONFIG                                                             *litee-config*
@@ -322,10 +331,10 @@ The config table is described below:
         -- this can be helpful for top/bottom layouts where you have more width
         -- then height.
         relative_filetree_entries = false,
+        --
+        -- disable all default keymaps.
+        disable_default_keymaps = false
     }
-
-For an example configuration with suggested keymaps refer to my dotfiles:
-https://github.com/ldelossa/dotfiles/blob/master/nvim/lua/configs/litee.lua
 
 ====================================================================================
 HIGHLIGHTS                                                     *litee-highlights*

--- a/doc/litee.txt
+++ b/doc/litee.txt
@@ -237,6 +237,15 @@ a LITEE.nvim window.
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTSelectFiletree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTDeSelectFiletree<CR>", opts)
 
+To disable the above default mappings, you can set config.disable_default_keymaps to true.
+
+To add your own keymaps, you can use the filetype "litee" to narrow the bindings to 
+be mapped solely on Litee side buffers:
+
+  vim.cmd(([[
+  autocmd Filetype calltree lua vim.api.nvim_set_keymap("n", "<Tab>", ":LTExpand<CR>", {})
+  autocmd Filetype calltree lua vim.api.nvim_set_keymap("n", ...)
+  ]]))
 
 ====================================================================================
 CONFIG                                                             *litee-config*
@@ -322,10 +331,10 @@ The config table is described below:
         -- this can be helpful for top/bottom layouts where you have more width
         -- then height.
         relative_filetree_entries = false,
+        --
+        -- disable the default keymaps.
+        disable_default_keymaps = false
     }
-
-For an example configuration with suggested keymaps refer to my dotfiles:
-https://github.com/ldelossa/dotfiles/blob/master/nvim/lua/configs/litee.lua
 
 ====================================================================================
 HIGHLIGHTS                                                     *litee-highlights*

--- a/lua/litee.lua
+++ b/lua/litee.lua
@@ -17,7 +17,8 @@ M.config = {
     map_resize_keys = true,
     hide_cursor = false,
     enable_notify = true,
-    relative_filetree_entries = false
+    relative_filetree_entries = false,
+    disable_default_bindings = false
 }
 
 local function _setup_default_highlights()

--- a/lua/litee/ui/buffer.lua
+++ b/lua/litee/ui/buffer.lua
@@ -115,7 +115,7 @@ function M._setup_buffer(name, buffer_handle, tab, type)
     -- set buf options
     vim.api.nvim_buf_set_name(buffer_handle, name .. ":" .. tab)
     vim.api.nvim_buf_set_option(buffer_handle, 'bufhidden', 'hide')
-    vim.api.nvim_buf_set_option(buffer_handle, 'filetype', 'Calltree')
+    vim.api.nvim_buf_set_option(buffer_handle, 'filetype', 'litee')
     vim.api.nvim_buf_set_option(buffer_handle, 'buftype', 'nofile')
     vim.api.nvim_buf_set_option(buffer_handle, 'modifiable', false)
     vim.api.nvim_buf_set_option(buffer_handle, 'swapfile', false)

--- a/lua/litee/ui/buffer.lua
+++ b/lua/litee/ui/buffer.lua
@@ -155,32 +155,34 @@ function M._setup_buffer(name, buffer_handle, tab, type)
         close_cmd = ":LTCloseFiletree<CR>"
     end
     local opts = {silent=true}
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zo", ":LTExpand<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zc", ":LTCollapse<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zM", ":LTCollapseAll<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<CR>", ":LTJump<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTJumpSplit<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "v", ":LTJumpVSplit<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "t", ":LTJumpTab<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "f", ":LTFocus<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "i", ":LTHover<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":LTDetails<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTSwitch<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('litee.ui').help(true)<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "H", ":lua require('litee.ui')._smart_close()<CR>", opts)
-    if type == "filetree" then
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "x", close_cmd, opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "n", ":LTTouchFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "D", ":LTRemoveFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":LTMkdirFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "r", ":LTRenameFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "m", ":LTMoveFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "p", ":LTCopyFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTSelectFiletree<CR>", opts)
-        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTDeSelectFiletree<CR>", opts)
-    end
-	if config.map_resize_keys then
+    if config.disable_default_bindings then
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zo", ":LTExpand<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zc", ":LTCollapse<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "zM", ":LTCollapseAll<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<CR>", ":LTJump<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTJumpSplit<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "v", ":LTJumpVSplit<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "t", ":LTJumpTab<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "f", ":LTFocus<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "i", ":LTHover<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":LTDetails<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTSwitch<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('litee.ui').help(true)<CR>", opts)
+      vim.api.nvim_buf_set_keymap(buffer_handle, "n", "H", ":lua require('litee.ui')._smart_close()<CR>", opts)
+      if type == "filetree" then
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "x", close_cmd, opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "n", ":LTTouchFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "D", ":LTRemoveFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":LTMkdirFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "r", ":LTRenameFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "m", ":LTMoveFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "p", ":LTCopyFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":LTSelectFiletree<CR>", opts)
+          vim.api.nvim_buf_set_keymap(buffer_handle, "n", "S", ":LTDeSelectFiletree<CR>", opts)
+      end
+      if config.map_resize_keys then
         map_resize_keys(buffer_handle, opts)
+      end
     end
     return buffer_handle
 end


### PR DESCRIPTION
Fixes #78 

@ldelossa I added along the way a configuration option to disable all default bindings, as this is rather inconvenient otherwise when mapping everything on your own.