### PR TITLE
Fix duplicate doc tag

### DIFF
--- a/doc/litee.txt
+++ b/doc/litee.txt
@@ -1,4 +1,4 @@
-*LITEE.nvim* LITEE.nvim
+*LITEE.txt* LITEE.nvim
 *LITEE.nvim*
 
 Author:   Louis DeLosSantos <louis.delos@gmail.com>


### PR DESCRIPTION
Generating help tags fails without this fix. Here's the script we use in NixOS:
https://github.com/NixOS/nixpkgs/blob/21.11/pkgs/misc/vim-plugins/vim-gen-doc-hook.sh

This duplicate tag was not present before the refactor:
https://github.com/ners/litee.nvim/blob/f208798a2f46ae8e31195a99ffa6e192782e59cb/doc/calltree.txt