### PR TITLE
feat,term: introduce lib term

### DIFF
--- a/doc/litee.txt
+++ b/doc/litee.txt
@@ -26,7 +26,8 @@ CONTENTS                                                            *litee-conte
   11    lib/panel......................................|litee-lib-panel|  
   12    lib/state......................................|litee-lib-state|  
   13    lib/tree........................................|litee-lib-tree|  
-  14   lib/util........................................|litee-lib-util|  
+  14    lib/util........................................|litee-lib-util|  
+  15    lib/term........................................|litee-lib-term|  
 
 ====================================================================================
 INTRODUCTION                                                           *litee-intro*
@@ -438,3 +439,48 @@ Lib `util` is a dumping ground for various helper functions and utilities.
 
 As `litee.nvim` matures methods in this library will fall into thier own 
 submodules such as "lib.util.window" and "lib.util.buffer", etc...
+
+====================================================================================
+lib/term                                                            *litee-lib-term*
+
+Lib `term` exports a method for opening a Neovim native terminal that is aware
+of `litee.nvim` environment. 
+
+This terminal can be opened on the top or bottom and is controlled by the "term"
+configuration block in the `lib.config` module.
+
+```
+    term = {
+        -- can be  "top" or "bottom"
+        position = "bottom",
+        -- the initial size of the terminal
+        term_size = 15,
+        -- if true maps arrow keys to window resize
+        -- commands.
+        map_resize_keys = true,
+    },
+````
+
+The terminal creates two "terminal" mode key bindings. 
+
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>v", "<cmd>lua require('configs.terminal').terminal_vsplit()<cr>", opts)
+
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>n", "<C-\\><C-n>", opts)
+
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>h", "<C-\\><C-n> <C-w>h", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>j", "<C-\\><C-n> <C-w>j", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>k", "<C-\\><C-n> <C-w>k", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>l", "<C-\\><C-n> <C-w>l", opts)
+
+The first one will open another terminal in a vsplit relative to the terminal you're issuing
+the command in.
+
+The second is a helper that puts your terminal back into normal mode. 
+
+The final set are short-cuts for jumping out of the terminal into other windows.
+
+Be aware, these mappins will only work when your Vim mode is "terminal" which is when
+input is being forwarded directly to the shell. If you are in normal mode (the shell is just
+a buffer of lines at that point) the mappins will revert back to normal mode mappings.
+
+The term can be triggered open with the "LTTerm" user command.

--- a/lua/litee/lib/commands.lua
+++ b/lua/litee/lib/commands.lua
@@ -4,6 +4,8 @@ local M = {}
 -- setup.
 function M.setup()
     vim.cmd("command! LTPanel lua require('litee.lib.panel').toggle_panel()")
+    vim.cmd("command! LTTerm        lua require('litee.lib.term').terminal()")
+    vim.cmd("command! LTClearJumpHL lua require('litee.lib.jumps').set_jump_hl(false)")
 end
 
 return M

--- a/lua/litee/lib/config.lua
+++ b/lua/litee/lib/config.lua
@@ -18,6 +18,11 @@ M.config = {
         panel_size = 30,
     },
     state = {},
+    term = {
+        position = "bottom",
+        term_size = 15,
+        map_resize_keys = true,
+    },
     tree = {
         icon_set = "default",
         indent_guides = true

--- a/lua/litee/lib/term/init.lua
+++ b/lua/litee/lib/term/init.lua
@@ -1,0 +1,84 @@
+local lib_panel = require('litee.lib.panel')
+local lib_util_buf = require('litee.lib.util.buffer')
+local config = require('litee.lib.config').config["term"]
+
+local M = {}
+
+local opts = {noremap = true, silent=true}
+local function terminal_buf_setup(buf)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>v", "<cmd>lua require('configs.terminal').terminal_vsplit()<cr>", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>n", "<C-\\><C-n>", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>h", "<C-\\><C-n> <C-w>h", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>j", "<C-\\><C-n> <C-w>j", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>k", "<C-\\><C-n> <C-w>k", opts)
+    vim.api.nvim_buf_set_keymap(buf, 't', "<C-w>l", "<C-\\><C-n> <C-w>l", opts)
+    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
+	if config.map_resize_keys then
+           lib_util_buf.map_resize_keys(config.position, buf, opts)
+    end
+end
+local function terminal_win_setup(win)
+    vim.api.nvim_win_set_option(win, 'winfixheight', true)
+end
+
+-- terminal opens a native Neovim terminal instance that
+-- is aware of the litee.panel layout.
+--
+-- the terminal will not truncate the panel if it is open
+-- on the left or right position.
+--
+-- the terminal can be opened at the top of bottom of the
+-- editor, but not left or right and this is configured
+-- via the 'litee.lib.config.term["position"]' stanza.
+--
+-- the terminal has a fixed height so a call to <C-w>=
+-- does not effect the height and only evenly spaces
+-- any vsplit terminals in the pane.
+--
+-- the $SHELL environment variable must be set correctly
+-- to open the appropriate shell.
+function M.terminal()
+    local shell = vim.fn.getenv('SHELL')
+    if shell == nil or shell == "" then
+        return
+    end
+    local buf = vim.api.nvim_create_buf(false, false)
+    if buf == 0 then
+        vim.api.nvim_err_writeln("failed to create terminal buffer")
+        return
+    end
+
+    terminal_buf_setup(buf)
+
+    if config.position == "top" then
+        vim.cmd('topleft split')
+    else
+        vim.cmd('botright split')
+    end
+    vim.cmd("resize " .. config.term_size)
+    terminal_win_setup(vim.api.nvim_get_current_win())
+
+    local cur_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(vim.api.nvim_get_current_win, buf)
+    vim.fn.termopen(shell)
+    lib_panel.toggle_panel_ctx(true, true)
+    vim.api.nvim_set_current_win(cur_win)
+end
+
+function M.terminal_vsplit()
+    local shell = vim.fn.getenv('SHELL')
+    if shell == nil or shell == "" then
+        return
+    end
+    local buf = vim.api.nvim_create_buf(false, false)
+    if buf == 0 then
+        vim.api.nvim_err_writeln("failed to create terminal buffer")
+        return
+    end
+    terminal_buf_setup(buf)
+    vim.cmd('vsplit')
+    terminal_win_setup(vim.api.nvim_get_current_win())
+    vim.api.nvim_win_set_buf(vim.api.nvim_get_current_win, buf)
+    vim.fn.termopen(shell)
+end
+return M


### PR DESCRIPTION
lib term provides a "litee.nvim" aware terminal.

the term is Neovim's built in terminal emulator called with the $SHELL
variable as its attached process.

this is useful as spawning a term will not fight with any currently
open litee.panel instance.

see (h: litee-lib-term) for full details

Signed-off-by: ldelossa <louis.delos@gmail.com>