### PR TITLE
Popout Panels

### DIFF
--- a/lua/litee/lib/commands.lua
+++ b/lua/litee/lib/commands.lua
@@ -3,9 +3,10 @@ local M = {}
 -- commands will setup any Vim commands exported on litee.lib
 -- setup.
 function M.setup()
-    vim.cmd("command! LTPanel lua require('litee.lib.panel').toggle_panel()")
-    vim.cmd("command! LTTerm        lua require('litee.lib.term').terminal()")
-    vim.cmd("command! LTClearJumpHL lua require('litee.lib.jumps').set_jump_hl(false)")
+    vim.cmd("command! LTPanel           lua require('litee.lib.panel').toggle_panel()")
+    vim.cmd("command! LTTerm            lua require('litee.lib.term').terminal()")
+    vim.cmd("command! LTClearJumpHL     lua require('litee.lib.jumps').set_jump_hl(false)")
+    vim.cmd("command! LTClosePanelPopOut lua require('litee.lib.panel').close_current_popout()")
 end
 
 return M

--- a/lua/litee/lib/jumps/init.lua
+++ b/lua/litee/lib/jumps/init.lua
@@ -1,5 +1,6 @@
 local config    = require('litee.lib.config').config
 local lib_hi    = require('litee.lib.highlights')
+local lib_panel = require('litee.lib.panel')
 
 local M = {}
 
@@ -58,6 +59,9 @@ function M.jump_tab(location, node)
     M.set_jump_hl(false, nil)
     vim.cmd("tabedit " .. location.uri)
     vim.cmd("set nocursorline")
+    -- if the panel currently has a component "popped-out"
+    -- close it before jumping.
+    lib_panel.close_current_popout()
     vim.lsp.util.jump_to_location(location)
     M.set_jump_hl(true, node)
 end
@@ -76,6 +80,9 @@ function M.jump_split(split, location, node)
     if not move_or_create(config["panel"].orientation) then
         vim.cmd(split)
     end
+    -- if the panel currently has a component "popped-out"
+    -- close it before jumping.
+    lib_panel.close_current_popout()
     vim.lsp.util.jump_to_location(location)
     M.set_jump_hl(true, node)
 end
@@ -93,6 +100,9 @@ end
 function M.jump_neighbor(location, node)
     M.set_jump_hl(false, nil)
     move_or_create(config["panel"].orientation)
+    -- if the panel currently has a component "popped-out"
+    -- close it before jumping.
+    lib_panel.close_current_popout()
     vim.lsp.util.jump_to_location(location)
     M.set_jump_hl(true, node)
 end
@@ -125,6 +135,9 @@ function M.jump_invoking(location, win, node)
         win = vim.api.nvim_get_current_win()
     end
     vim.api.nvim_set_current_win(win)
+    -- if the panel currently has a component "popped-out"
+    -- close it before jumping.
+    lib_panel.close_current_popout()
     vim.lsp.util.jump_to_location(location)
     M.set_jump_hl(true, node)
     return win
@@ -139,7 +152,7 @@ end
 -- @param node (table) An element which is being jumped to,
 -- the node must have a high level ".location" field.
 -- if this element has a high level ".references" field with
--- an array of "Range" objects (specified by LSP), 
+-- an array of "Range" objects (specified by LSP),
 -- they will be highlighted as well.
 function M.set_jump_hl(set, node)
     if not set then

--- a/lua/litee/lib/panel/autocmds.lua
+++ b/lua/litee/lib/panel/autocmds.lua
@@ -10,10 +10,11 @@ function M.on_resize()
     if state == nil then
         return
     end
-    lib_panel.toggle_panel(state, false, true)
-    -- restore window
-    vim.api.nvim_set_current_win(cur_win)
-    vim.cmd("redraw!")
+    local is_open = lib_panel.is_panel_open(state)
+    if is_open then
+        lib_panel.toggle_panel(state, false, true)
+        vim.api.nvim_set_current_win(cur_win)
+    end
 end
 
 return M


### PR DESCRIPTION
this commit introduces a feature where panel components can be "popped
out" of the panel into a float on the lower right-hand side of the
editor.

a popout can occur both when the panel is closed and open. if a popout
is triggered when the panel is open the window is removed from the panel
and placed back into the panel when the "LTClosePanelPopOut" command is
issued.

if the panel is closed, it is transparently opened to generate all
component buffers and windows and the requested component window is made
into a float. the other windows are then closed.

a user could opt to use only popups and if they desire, all components
with active state will always be available when toggling the panel
regardless.