### PR TITLE
edit: escape icons

### DIFF
--- a/lua/litee/lib/icons/init.lua
+++ b/lua/litee/lib/icons/init.lua
@@ -140,7 +140,7 @@ M.codicons = {
 
 M.default = {
     Account         = "🗣",
-    Array           = "[]",
+    Array           = "\\[\\]",
     Bookmark        = "🏷",
     Boolean         = "∧",
     Calendar        = '🗓',
@@ -167,7 +167,7 @@ M.default = {
     File            = "🗀",
     Folder          = "🗁",
     Function        = "ƒ",
-    GitBranch       = '',
+    GitBranch       = ' ',
     GitCommit       = '⫰',
     GitCompare      = '⤄',
     GitIssue        = '⊙',


### PR DESCRIPTION
I was getting `Pattern delimiter not found: /[]/` errors in `gh.nvim` until i made these two changes in litee.

empty string (as opposed to space) and brackets creates problems for replacer function in window.lua

