### PR TITLE
fix: wrong param of lsp client request and offset_encoding warning

### DIFF
--- a/lua/litee/lib/jumps/init.lua
+++ b/lua/litee/lib/jumps/init.lua
@@ -55,14 +55,14 @@ end
 -- @param node (table) An element which is being jumped to,
 -- if this element has a high level "references" field with
 -- more "Location" objects, they will be highlighted as well.
-function M.jump_tab(location, node)
+function M.jump_tab(location, node, offset_encoding)
     M.set_jump_hl(false, nil)
     vim.cmd("tabedit " .. location.uri)
     vim.cmd("set nocursorline")
     -- if the panel currently has a component "popped-out"
     -- close it before jumping.
     lib_panel.close_current_popout()
-    vim.lsp.util.jump_to_location(location)
+    vim.lsp.util.jump_to_location(location, offset_encoding or "utf-8")
     M.set_jump_hl(true, node)
 end
 
@@ -75,7 +75,7 @@ end
 -- @param node (table) An element which is being jumped to,
 -- if this element has a high level "references" field with
 -- more "Location" objects, they will be highlighted as well.
-function M.jump_split(split, location, node)
+function M.jump_split(split, location, node, offset_encoding)
     M.set_jump_hl(false, nil)
     if not move_or_create(config["panel"].orientation) then
         vim.cmd(split)
@@ -83,7 +83,7 @@ function M.jump_split(split, location, node)
     -- if the panel currently has a component "popped-out"
     -- close it before jumping.
     lib_panel.close_current_popout()
-    vim.lsp.util.jump_to_location(location)
+    vim.lsp.util.jump_to_location(location, offset_encoding or "utf-8")
     M.set_jump_hl(true, node)
 end
 
@@ -97,13 +97,13 @@ end
 -- @param node (table) An element which is being jumped to,
 -- if this element has a high level "references" field with
 -- more "Location" objects, they will be highlighted as well.
-function M.jump_neighbor(location, node)
+function M.jump_neighbor(location, node, offset_encoding)
     M.set_jump_hl(false, nil)
     move_or_create(config["panel"].orientation)
     -- if the panel currently has a component "popped-out"
     -- close it before jumping.
     lib_panel.close_current_popout()
-    vim.lsp.util.jump_to_location(location)
+    vim.lsp.util.jump_to_location(location, offset_encoding or "utf-8")
     M.set_jump_hl(true, node)
 
     -- cleanup any [No Name] buffers if they exist
@@ -128,7 +128,7 @@ end
 -- @param node (table) An element which is being jumped to,
 -- if this element has a high level "references" field with
 -- more "Location" objects, they will be highlighted as well.
-function M.jump_invoking(location, win, node)
+function M.jump_invoking(location, win, node, offset_encoding)
     M.set_jump_hl(false, nil)
     if not vim.api.nvim_win_is_valid(win) then
         if config["panel"].orientation == "left" then
@@ -147,7 +147,7 @@ function M.jump_invoking(location, win, node)
     -- if the panel currently has a component "popped-out"
     -- close it before jumping.
     lib_panel.close_current_popout()
-    vim.lsp.util.jump_to_location(location)
+    vim.lsp.util.jump_to_location(location, offset_encoding or "utf-8")
     M.set_jump_hl(true, node)
 
     -- cleanup any [No Name] buffers if they exist

--- a/lua/litee/lib/lsp/init.lua
+++ b/lua/litee/lib/lsp/init.lua
@@ -12,7 +12,7 @@ function M.multi_client_request(clients, method, params, handler, bufnr)
         if not client.supports_method(method) then
             goto continue
         end
-        client.request(method, params, handler, bufnr)
+        client.request(method, params, handler, bufnr or 0)
         ::continue::
     end
 end
@@ -75,8 +75,7 @@ function M.gather_symbols_async(root, children, component_state, callback)
                 "workspace/symbol",
                 params,
                 -- handler will call resume for this co.
-                M.gather_symbols_async_handler(node, co),
-                component_state.invoking_win
+                M.gather_symbols_async_handler(node, co)
             )
             node.symbol = coroutine.yield()
             lib_notify.close_notify_popup()

--- a/lua/litee/lib/tree/node.lua
+++ b/lua/litee/lib/tree/node.lua
@@ -47,6 +47,7 @@ function M.new_node(name, key, depth)
         -- whether this node is expanded in its containing
         -- tree.
         expanded = false,
+        offset_encoding = "utf-8"
     }
 end
 


### PR DESCRIPTION
1. last param of lsp client request method should be bufnr but not win
2. if `vim.lsp.util.jump_to_location` does not have `offset_encoding` param, it gives a warning