### PR TITLE
Fix: limit icon pattern to single token

### DIFF
--- a/lua/litee/lib/util/window.lua
+++ b/lua/litee/lib/util/window.lua
@@ -19,7 +19,7 @@ function M.set_tree_highlights()
     end
     -- set configured icon highlights
     for icon, hl in pairs(lib_icons.icon_hls) do
-        vim.cmd(string.format("syn match %s /%s/", hl, icon_set[icon]))
+        vim.cmd(string.format("syn match %s /\\<%s\\>/", hl, icon_set[icon]))
     end
     -- set configured symbol highlight
     vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.SymbolHL, [[\w]]))
@@ -27,10 +27,10 @@ function M.set_tree_highlights()
     vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.SymbolHL, [[\-]]))
     vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.SymbolHL, [[\\_]]))
     -- set configured expanded indicator highlights
-    vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.ExpandedGuideHL, icon_set["Expanded"]))
-    vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.CollapsedGuideHL, icon_set["Collapsed"]))
+    vim.cmd(string.format("syn match %s /\\<%s\\>/", lib_hi.hls.ExpandedGuideHL, icon_set["Expanded"]))
+    vim.cmd(string.format("syn match %s /\\<%s\\>/", lib_hi.hls.CollapsedGuideHL, icon_set["Collapsed"]))
     -- set configured indent guide highlight
-    vim.cmd(string.format("syn match %s /%s/", lib_hi.hls.IndentGuideHL, icon_set["Guide"]))
+    vim.cmd(string.format("syn match %s /\\<%s\\>/", lib_hi.hls.IndentGuideHL, icon_set["Guide"]))
 end
 
 -- inside_component_win is a helper functions which


### PR DESCRIPTION
When icons uses normal letters, like the 'simple' icon set for example, the highlight matching will also apply to all other instances of these icons, even within other words. Consider the case when 'Expanded' icon is set to 'v', then the underlined part of the example below will use same highlight as 'LTExpanded'

  X some_symbol_with_v
                     ~

This change makes icon symbol matching cover the entire words/tokens, instead of parts of